### PR TITLE
Transpile from ES2015 and ES2017 to ES5.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
       "targets": {
         "node": "current"
       }
-    }]
+    }],
+    "es2015",
+    "es2017"
   ],
   "plugins": ["transform-runtime", "transform-decorators-legacy"]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "type": "git",
     "url": "git+https://github.com/ProjectOpenSea/ethmoji-js.git"
   },
-  "keywords": ["ethereum", "ethmoji", "smart-contracts"],
+  "keywords": [
+    "ethereum",
+    "ethmoji",
+    "smart-contracts"
+  ],
   "author": "support@opensea.io",
   "license": "ISC",
   "bugs": {
@@ -37,6 +41,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es2017": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",


### PR DESCRIPTION
The current transpiled output of `babel` fails to build in create-react-app because of ES2015 (**let** keyword) and ES2017 (**async/await**) features:
```
mrbrown@hypervisor:~/git/igetgames/cra-ethmoji-js-test
$ yarn build
yarn run v1.5.1
$ react-scripts build
Creating an optimized production build...
Failed to compile.

Failed to minify the code from this file:

 	./node_modules/ethmoji-js/lib/index.js:65

Read more here: http://bit.ly/2tRViJ9
...
```

To fix this, I added the ES2017 `babel` preset and enabled both ES2015 and ES2017 presets in `.babelrc`.